### PR TITLE
Fix dark theme text contrast and SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Soluciones de software a medida para inventario, facturación, contabilidad y control de gasolineras en Guatemala">
+  <meta name="keywords" content="software a medida, inventario, facturación, contabilidad, gasolineras, Guatemala">
   <title>E‑Sistemas Globales</title>
   <link rel="shortcut icon" href="assets/img/logo/favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
@@ -418,6 +420,7 @@
         left: 0;
         width: 100%;
         background: #fff;
+        color: var(--text-dark);
         max-height: 0;
         overflow: hidden;
         transition: max-height .3s ease;
@@ -425,6 +428,7 @@
 
       body.dark nav {
         background: #2d3748;
+        color: var(--text-dark);
       }
 
       nav.open {
@@ -530,7 +534,7 @@
 
   <header>
     <div class="container nav-wrap">
-      <div class="logo"><img src="assets/img/logo/e.sistemas-logo-white.png" alt="" style="width: 8rem;"></div>
+      <div class="logo"><img src="assets/img/logo/e.sistemas-logo-white.png" alt="Logo de E‑Sistemas Globales" style="width: 8rem;"></div>
 
       <!-- Controles de navegación y tema -->
       <div style="display:flex;align-items:center;gap:.75rem;">
@@ -659,7 +663,7 @@
     <!-- About -->
     <section id="about" class="about">
       <div style="text-align: center;">
-        <img src="assets/img/logo/sistemas-globales-contorno-blanco.png" alt="" style="display:block;margin:0 auto 1.5rem;max-width:320px;">
+        <img src="assets/img/logo/sistemas-globales-contorno-blanco.png" alt="Logotipo de E‑Sistemas Globales" style="display:block;margin:0 auto 1.5rem;max-width:320px;">
         <h2>Tu aliado en transformación digital</h2>
         <p style="color:#fff;">En <strong>ESG Petén</strong> diseñamos software a la medida para optimizar cada área
           crítica de tu negocio:
@@ -898,7 +902,7 @@
         <div style="max-width:700px;margin:0 auto;">
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Icono pregunta" style="width:28px;height:28px;">
               ¿Qué tipo de software desarrollan?
             </summary>
             <div>
@@ -911,7 +915,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/support.svg" alt=""
+              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/support.svg" alt="Icono soporte" 
                 style="width:28px;height:28px;">
               ¿Ofrecen soporte técnico?
             </summary>
@@ -924,7 +928,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/eye.svg" alt=""
+              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/eye.svg" alt="Icono demo" 
                 style="width:28px;height:28px;">
               ¿Puedo solicitar una demo gratuita?
             </summary>
@@ -937,7 +941,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/growth.svg" alt=""
+              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/growth.svg" alt="Icono crecimiento" 
                 style="width:28px;height:28px;">
               ¿El software es escalable?
             </summary>
@@ -949,7 +953,7 @@
           </details>
           <details>
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/contact.svg" alt=""
+              <img src="https://cdn.jsdelivr.net/gh/edent/SuperTinyIcons/images/svg/contact.svg" alt="Icono contacto" 
                 style="width:28px;height:28px;">
               ¿Cómo solicito una cotización?
             </summary>


### PR DESCRIPTION
## Summary
- ensure navigation text has contrast in mobile view
- add descriptive alt text for images
- include meta description and keywords for SEO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6871b325c4548322b743ce9d0c2badc9