### PR TITLE
Fix FAQ link path

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,7 @@
               <a href="faq/cierre-caja.html" class="btn-ghost">Leer más</a>
             </div>
           </details>
-          <a href="/faqs.html" class="btn-ver-mas">Ver más preguntas</a>
+          <a href="faqs.html" class="btn-ver-mas">Ver más preguntas</a>
       </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- fix `href` for FAQ button so it correctly points to `faqs.html`

## Testing
- `bash gen_faq.sh`

------
https://chatgpt.com/codex/tasks/task_b_6871b90d7668832295de3210826ac646