### PR TITLE
Fix dark theme text contrast and SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="E‑Sistemas Globales desarrolla software a medida para inventarios, facturación y contabilidad en Guatemala">
+  <meta name="keywords" content="software a medida, inventarios, facturación, contabilidad, Guatemala">
+  <meta property="og:title" content="E‑Sistemas Globales">
+  <meta property="og:description" content="Soluciones de software empresarial a medida en Guatemala">
+  <meta property="og:image" content="assets/img/logo/e.sistemas-logo-white.png">
   <title>E‑Sistemas Globales</title>
   <link rel="shortcut icon" href="assets/img/logo/favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
@@ -541,7 +546,7 @@
 
   <header>
     <div class="container nav-wrap">
-      <div class="logo"><img src="assets/img/logo/e.sistemas-logo-white.png" alt="" style="width: 8rem;"></div>
+      <div class="logo"><img src="assets/img/logo/e.sistemas-logo-white.png" alt="Logotipo de E‑Sistemas Globales" style="width: 8rem;"></div>
 
       <!-- Controles de navegación y tema -->
       <div style="display:flex;align-items:center;gap:.75rem;">
@@ -594,8 +599,8 @@
     <!-- HERO -->
     <section id="home" class="hero">
       <div class="hero__content">
-        <h1 style="color: white;">Impulsa tu empresa con software a medida</h1>
-        <p style="color: white;">
+        <h1 style="color: var(--text-dark);">Impulsa tu empresa con software a medida</h1>
+        <p style="color: var(--text-dark);">
           Optimizamos tu Inventario, Facturación, Contabilidad y Control de Gasolineras
           con soluciones fáciles de usar y&nbsp;100 % escalables.
         </p>
@@ -670,7 +675,7 @@
     <!-- About -->
     <section id="about" class="about">
       <div style="text-align: center;">
-        <img src="assets/img/logo/sistemas-globales-contorno-blanco.png" alt="" style="display:block;margin:0 auto 1.5rem;max-width:320px;">
+        <img src="assets/img/logo/sistemas-globales-contorno-blanco.png" alt="Logotipo de E‑Sistemas Globales" style="display:block;margin:0 auto 1.5rem;max-width:320px;">
         <h2>Tu aliado en transformación digital</h2>
         <p style="color:#fff;">En <strong>ESG Petén</strong> diseñamos software a la medida para optimizar cada área
           crítica de tu negocio:
@@ -909,7 +914,7 @@
           <div style="max-width:700px;margin:0 auto;">
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo creo un nuevo cliente según su tipo de documento (NIT, CF, DPI)?
             </summary>
             <div>
@@ -919,7 +924,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo registro correctamente una compra en SIP5 WEB?
             </summary>
             <div>
@@ -929,7 +934,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cuál es el proceso para crear un producto en el sistema SIP5 WEB?
             </summary>
             <div>
@@ -939,7 +944,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Dónde consulto y descargo el libro de ventas y compras?
             </summary>
             <div>
@@ -949,7 +954,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo puedo modificar un turno cerrado por error?
             </summary>
             <div>
@@ -959,7 +964,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Qué pasos debo seguir para realizar el cierre de un turno correctamente?
             </summary>
             <div>
@@ -969,7 +974,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Dónde puedo revisar el stock actual de mis productos?
             </summary>
             <div>
@@ -979,7 +984,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo agrego nuevos proveedores y categorías al sistema?
             </summary>
             <div>
@@ -989,7 +994,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo registro un gasto y evito duplicidades en el sistema?
             </summary>
             <div>
@@ -999,7 +1004,7 @@
           </details>
           <details style="margin-bottom:1.2rem;">
             <summary style="font-weight:600;cursor:pointer;display:flex;align-items:center;gap:.7rem;">
-              <img src="assets/img/clientes/01.jpg" alt="" style="width:28px;height:28px;">
+              <img src="assets/img/clientes/01.jpg" alt="Ícono de pregunta" style="width:28px;height:28px;">
               ¿Cómo realizo el cierre de caja al final del día?
             </summary>
             <div>
@@ -1035,7 +1040,7 @@
             <img src="assets/img/clientes/01.jpg" alt="Imagen del Post 1"
               style="width:100%;border-radius:0.5rem 0.5rem 0 0;margin-bottom:1rem;">
             <h3>Título de Post 1</h3>
-            <p style="color: white;">Resumen breve del post para atraer clics.</p>
+            <p style="color: var(--text-dark);">Resumen breve del post para atraer clics.</p>
             <a href="#"
               style="display:inline-block;background:#fff;color:#012e5e;padding:0.6rem 1.2rem;border-radius:0.4rem;font-weight:600;text-align:center;margin-top:1rem;transition:background .2s;">Leer
               más&nbsp;→</a>
@@ -1046,7 +1051,7 @@
             <img src="assets/img/clientes/02.jpg" alt="Imagen del Post 2"
               style="width:100%;border-radius:0.5rem 0.5rem 0 0;margin-bottom:1rem;">
             <h3>Título de Post 2</h3>
-            <p style="color: white;">Resumen breve del post para atraer clics.</p>
+            <p style="color: var(--text-dark);">Resumen breve del post para atraer clics.</p>
             <a href="#"
               style="display:inline-block;background:#fff;color:#012e5e;padding:0.6rem 1.2rem;border-radius:0.4rem;font-weight:600;text-align:center;margin-top:1rem;transition:background .2s;">Leer
               más&nbsp;→</a>
@@ -1056,7 +1061,7 @@
             <img src="assets/img/clientes/03.jpg" alt="Imagen del Post 3"
               style="width:100%;border-radius:0.5rem 0.5rem 0 0;margin-bottom:1rem;">
             <h3>Título de Post 3</h3>
-            <p style="color: white;">Resumen breve del post para atraer clics.</p>
+            <p style="color: var(--text-dark);">Resumen breve del post para atraer clics.</p>
             <a href="#"
               style="display:inline-block;background:#fff;color:#012e5e;padding:0.6rem 1.2rem;border-radius:0.4rem;font-weight:600;text-align:center;margin-top:1rem;transition:background .2s;">Leer
               más&nbsp;→</a>


### PR DESCRIPTION
## Summary
- improve SEO meta tags
- update alt text on logos and FAQ icons
- make hero and blog text adapt to themes

## Testing
- `bash gen_faq.sh` *(no output)*

------
https://chatgpt.com/codex/tasks/task_b_6871bb7472c483229b8a91ae32dfcdb3